### PR TITLE
Removed hard coding of aircon in setZone

### DIFF
--- a/pymyair/pymyair.py
+++ b/pymyair/pymyair.py
@@ -102,7 +102,7 @@ class MyAir:
 
         zoneid = "z%02d" % id
 
-        setjson = "{\"ac1\":{\"zones\":{\"%s\":{" % zoneid
+        setjson = "{\"%s\":{\"zones\":{\"%s\":{" % (self._aircon, zoneid)
 
         if state is not None and state_value:
             setjson += "\"state\":\"%s\"" % state_value


### PR DESCRIPTION
setZone is hardcoded to AC1.  Changed this to be variable.